### PR TITLE
feat: detect the package manager used to customise next steps

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ const decompress = require("decompress");
 const stream = require("stream");
 const { promisify } = require("util");
 
+const { detectPackageManager, getPackageManagerCommands } = require("./utils");
+
 // Set up the CLI program
 program
   .name("create-rwsdk")
@@ -145,11 +147,15 @@ async function createProject(projectName, options) {
       )
     );
 
+    // Detect package manager and get appropriate commands
+    const packageManager = detectPackageManager();
+    const commands = getPackageManagerCommands(packageManager);
+
     // Display next steps
     console.log("\n" + chalk.bold("Next steps:"));
     console.log(`  cd ${projectName}`);
-    console.log("  npm install");
-    console.log("  npm run dev");
+    console.log(`  ${commands.install}`);
+    console.log(`  ${commands.dev}`);
     console.log("\nHappy coding! 🚀\n");
 
     // Ensure the process exits properly

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,41 @@
+// Function to detect the package manager used
+function detectPackageManager() {
+  const userAgent = process.env.npm_config_user_agent;
+  
+  if (userAgent) {
+    if (userAgent.includes('yarn')) {
+      return 'yarn';
+    } else if (userAgent.includes('pnpm')) {
+      return 'pnpm';
+    } else if (userAgent.includes('npm')) {
+      return 'npm';
+    }
+  }
+  
+  return 'npm';
+}
+
+// Function to get the appropriate commands for the detected package manager
+function getPackageManagerCommands(packageManager) {
+  const commands = {
+    npm: {
+      install: 'npm install',
+      dev: 'npm run dev'
+    },
+    yarn: {
+      install: 'yarn install',
+      dev: 'yarn dev'
+    },
+    pnpm: {
+      install: 'pnpm install',
+      dev: 'pnpm dev'
+    }
+  };
+  
+  return commands[packageManager] || commands.npm;
+}
+
+module.exports = {
+  detectPackageManager,
+  getPackageManagerCommands
+};


### PR DESCRIPTION
Resolves: #2 

Adds some utility functions which detect the package manager used to run `create-rwsdk` and customises the next steps section accordingly: 

**Pnpm**
```
Next steps:
  cd my-project
  pnpm install
  pnpm dev
```

**Yarn**
```
Next steps:
  cd my-project
  yarn install
  yarn dev
```

**Npm (default)**
```
Next steps:
  cd my-project
  npm install
  npm run dev
```