### PR TITLE
Fix missing comma in headers object

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,8 +177,8 @@ async function getLatestSDKRelease(releaseType = "latest") {
   try {
     const response = await fetch(GITHUB_API_URL, {
       headers: {
-        "User-Agent": "create-rwsdk" // GitHub API requires a User-Agent header
-        ...auth ? { Authorization: `Bearer ${auth}` } : {} // Providing an API token avoids being rate limited
+        "User-Agent": "create-rwsdk", // GitHub API requires a User-Agent header
+        ...(auth ? { Authorization: `Bearer ${auth}` } : {}), // Providing an API token avoids being rate limited
       },
     });
 


### PR DESCRIPTION
This prevented me from running the command. Small fix to the headers object where there was a comma missing causing parsing to fail.

Wrapped the ternary in parenthesis. If that's against the repository style happy to remove it!